### PR TITLE
Redirect root path to reminders

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('reminders'), { path: '/reminders'};
 });
 
 export default Router;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel() {
+    this.transitionTo('reminders')
+  }
+});

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  
+});

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,0 +1,3 @@
+<h1>Index</h1>
+
+{{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,0 +1,3 @@
+<h1>Reminders</h1>
+
+{{outlet}}

--- a/tests/unit/routes/index-test.js
+++ b/tests/unit/routes/index-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:index', 'Unit | Route | index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/routes/reminders-test.js
+++ b/tests/unit/routes/reminders-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:reminders', 'Unit | Route | reminders', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
## Purpose

Index sucks. We want to land on the reminders page. Also we're going to make sure that an H1 is rendering.

## Approach

It redirects the user to reminders from index.

### Learning

_Describe the research stage._

_Links to blog posts, patterns, libraries or add-ons used to solve this problem._

#### Blog Posts

### Open Questions and Pre-Merge TODOs

- [ ] Use Github checklists. When solved, check the box and explain the answer.

### Test coverage 

_Briefly describe what tests you have written and why._

### Merge Dependencies and Related Work

_Link to merge dependency issues or PRs._

### Follow-up tasks

- [Issue #2 (Example)](https://github.com/flexyford/pull-request/issues)

### Screenshots

#### Before

#### After