### PR TITLE
Add conditional in reminders.hbs, and write a test asserting it displ…

### DIFF
--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -2,11 +2,17 @@
 
 {{outlet}}
 
+{{#if model}}
+
 <div class='spec-reminders'>
   {{#each model as |reminder|}}
     {{reminder-item reminder=reminder}}
   {{/each}}
 </div>
+
+{{else}}
+  <p class='spec-no-reminder-prompt'>You have no reminders saved :( Click the New Reminder button below to add your first one!</p>
+{{/if}}
 
 {{#link-to 'reminders.new'}}
 <button class='add-reminder-btn'>Add New Reminder</button>

--- a/mirage/factories/reminder.js
+++ b/mirage/factories/reminder.js
@@ -1,8 +1,8 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  // title: () => faker.lorem.words().join(' ').capitalize(),
-  // date: () => faker.date.recent(3),
-  // notes: () => faker.lorem.paragraph(),
-  // pinned: false
+  title: () => faker.lorem.words().join(' ').capitalize(),
+  date: () => faker.date.recent(3),
+  notes: () => faker.lorem.paragraph(),
+  pinned: false
 });

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,3 +1,3 @@
 export default function(server) {
-  server.createList('reminder', 5);
+  server.createList('reminder', 0);
 }

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -55,3 +55,11 @@ test('adding new notes', function(assert) {
     })
   })
 })
+
+test('add new note prompt', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(find('.spec-no-reminder-prompt').length, 1, 'should display a prompt to create a reminder when none are present')
+  })
+})


### PR DESCRIPTION
## Purpose

Update reminder component to have a conditional that will only display notes if notes exist, with some sort of message on the default page that indicates to the user they should create a new note.

## Approach

Read docs! Realize this only takes like 4 lines of code! Crack a beer and wait for PRs to get merged!

### Learning

[Ember docs - conditionals](https://guides.emberjs.com/v2.2.0/templates/conditionals/) - Learnt us how to if/else w/ handlebars.

### Open Questions and Pre-Merge TODOs

- [x] Update reminder component to have a conditional that will only display notes if notes exist, with some sort of message on the default page that indicates to the user they should create a new note.


### Test coverage 

We wrote a single test making sure that if there are no notes displaying, a prompt to create a note will be displayed instead.

### Follow-up tasks

- TBA

### Screenshots

[I can't believe I took a screenshot of this](http://bit.ly/IqT6zt)